### PR TITLE
Improve docs and usage

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """
 md2html.py  –  Convert a restricted‑flavor Markdown file to standalone HTML
-────────────────────────────────────────────────────────────────────────────
-Spec‑sheet implemented:
+
+Usage:
+    python Main.py FILE.md [output.html]
+
+Features implemented:
 
 * Skip YAML front‑matter delimited by leading/ending lines with exactly `---`
 * Paragraphs → <p>
@@ -23,6 +26,8 @@ import sys
 import html
 from pathlib import Path
 from typing import List, Tuple
+
+USAGE = "Usage: python Main.py FILE.md [output.html]"
 
 # ────────────────────────────  regexes  ──────────────────────────────── #
 
@@ -153,7 +158,7 @@ function copySibling(btn){{navigator.clipboard.writeText(btn.nextElementSibling.
 
 def main() -> None:
     if len(sys.argv) < 2 or sys.argv[1] in {"-h", "--help"}:
-        print("Usage: md2html.py FILE.md [output.html]", file=sys.stderr)
+        print(USAGE, file=sys.stderr)
         sys.exit(1)
 
     in_path  = Path(sys.argv[1])

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-# Algo
-- Expect opening metdata section ---
-- default all text to basic p tags
-- all multi line code sections have copy to clipbaord button
-- within headers, NOT code sections, recognize italics, bold, underline, or backtick inline code
-- all images are found on directory up in graphics/ 
+# Markdown to HTML Converter
+
+This repository contains a Python script that turns a small subset of Markdown into a standalone HTML page. It is meant for quick static pages with minimal styling.
+
+## Algorithm Overview
+
+- Skip YAML front matter delimited by `---`.
+- Paragraphs become `<p>` tags.
+- ATX headers (`#` ... `######`) map to `<h1>`&ndash;`<h6>`.
+- Images written as `![[name.ext]]` are loaded from `../graphics/`.
+- Fenced code blocks are wrapped with a Copy button.
+- Inline markup for `*em*`, `_em_`, `**strong**`, `__underline__` and `` `code` `` is processed in headers and paragraphs.
+- All other text is left as plain text.
+
+## Usage
+
+```
+python Main.py FILE.md [output.html]
+```
+
+If the output path is omitted, `FILE.html` is created next to the input.  See `Pipeline_example.md` for an example and `test_md2html.py` for a basic test suite.


### PR DESCRIPTION
## Summary
- overhaul README with concise algorithm description and usage example
- add usage lines to the top module docstring in `Main.py`
- define a `USAGE` constant and reuse it for CLI help

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68512dbf50c48330aae36b853c372292