### PR TITLE
Add multiline LaTeX support

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -15,6 +15,7 @@ USAGE = "Usage: python Main.py FILE.md [output.html]"
 RE_IMAGE   = re.compile(r"^\s*!\[\[([^|\]]+)(?:\|[^]]*)?]]\s*$")
 RE_HEADER  = re.compile(r"^(#{1,6})\s*(.*)$")
 RE_FENCE   = re.compile(r"^```(\w*)\s*$")
+RE_LATEX_BLOCK = re.compile(r"^\$\$\s*$")
 RE_BLANK   = re.compile(r"^\s*$")
 
 # inline (apply in **this** order)
@@ -72,6 +73,19 @@ def markdown_to_html(md_text: str, title: str = "Document") -> str:
             out.append(
                 CODE_BLOCK_TEMPLATE.format(lang=lang, code=code)
             )
+            continue
+
+        # multiline LaTeX block delimited by $$
+        if RE_LATEX_BLOCK.match(line):
+            latex_lines = []
+            i += 1
+            while i < len(lines) and not RE_LATEX_BLOCK.match(lines[i]):
+                latex_lines.append(lines[i].rstrip("\n"))
+                i += 1
+            if i < len(lines):
+                i += 1  # skip closing $$
+            latex_content = "\n".join(latex_lines)
+            out.append(f"<p>$$\n{latex_content}\n$$</p>")
             continue
 
         # header

--- a/test_md2html.py
+++ b/test_md2html.py
@@ -11,6 +11,14 @@ class TestMd2Html(unittest.TestCase):
         self.assertIn('<button class="copy"', html)
         self.assertNotIn('title: sample', html)
 
+    def test_multiline_latex(self):
+        md = """$$\n\\begin{array}{rcl}\n2&5&7 \\\n2&5&7 \\\n\\end{array}\n$$"""
+        html = markdown_to_html(md, title="latex")
+        self.assertIn("<p>$$", html)
+        self.assertIn("\\begin{array}{rcl}", html)
+        self.assertIn("2&5&7", html)
+        self.assertIn("$$</p>", html)
+
     def test_pipeline_example(self):
         path = 'Pipeline_example.md'
         md_text = open(path, encoding='utf8').read()


### PR DESCRIPTION
## Summary
- support multiline LaTeX blocks delimited by `$$`
- test new LaTeX block handling

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851913f16808330996c31a95bf17ffd