### PR TITLE
Embed home page and link data in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Markdown to HTML Converter
 | filename | description | No. lines |
 |----------|----------|----------|
-| `Main.py`   | line by line parsing   | 175   |
+| `Main.py`   | line by line parsing   | 190   |
 | `templates.py`   | web templates   | 55   |
-| `test_md2html.py`   | tests   | 38   |
+| `test_md2html.py`   | tests   | 41   |
 
 This repository contains a Python script that turns a small subset of Markdown into a standalone HTML page. It is meant for quick static pages with minimal styling.
 
@@ -30,6 +30,11 @@ python Main.py FILE.md [output.html]
 ```
 
 If the output path is omitted, `FILE.html` is created next to the input.  See `Pipeline_example.md` for an example and `test_md2html.py` for a basic test suite.
+
+### Additional Information Embedded
+`markdown_to_html` now accepts a path to a home page, a list of site links and a
+list of directory links. These are appended to the generated HTML so the home
+page text is displayed and the links are clickable.
 
 #### Supported Markdown
 - [ ] inline images

--- a/home_page.md
+++ b/home_page.md
@@ -1,0 +1,2 @@
+This is the *home* page.
+Welcome!

--- a/test_md2html.py
+++ b/test_md2html.py
@@ -1,19 +1,28 @@
 import unittest
+from pathlib import Path
 from Main import markdown_to_html
+
+HOME_PAGE = Path('home_page.md')
+ROOT_DIR = Path('.')
+SITES = ['site1.html']
+DIRS = ['dir1/']
 
 class TestMd2Html(unittest.TestCase):
     def test_basic_features(self):
         md = """---\ntitle: sample\n---\n# Header *one*\n\nParagraph with **bold** and _em_.\n\n![[img.png]]\n\n```sh\necho hello\n```\n"""
-        html = markdown_to_html(md, title="sample")
+        html = markdown_to_html(md, HOME_PAGE, SITES, DIRS, ROOT_DIR, title="sample")
         self.assertIn('<h1>Header <em>one</em></h1>', html)
         self.assertIn('<p>Paragraph with <strong>bold</strong> and <em>em</em>.</p>', html)
         self.assertIn('<img src="../graphics/img.png" alt="img.png">', html)
         self.assertIn('<button class="copy"', html)
         self.assertNotIn('title: sample', html)
+        self.assertIn('This is the <em>home</em> page.', html)
+        self.assertIn('<a href="site1.html">site1.html</a>', html)
+        self.assertIn('<a href="dir1">dir1/</a>', html)
 
     def test_callout(self):
         md = "> [!NOTE] Title\n> body line"
-        html = markdown_to_html(md, title="callout")
+        html = markdown_to_html(md, HOME_PAGE, SITES, DIRS, ROOT_DIR, title="callout")
         self.assertIn('callout-note', html)
         self.assertIn('Title', html)
         self.assertIn('body line', html)
@@ -21,7 +30,7 @@ class TestMd2Html(unittest.TestCase):
 
     def test_multiline_latex(self):
         md = """$$\n\\begin{array}{rcl}\n2&5&7 \\\n2&5&7 \\\n\\end{array}\n$$"""
-        html = markdown_to_html(md, title="latex")
+        html = markdown_to_html(md, HOME_PAGE, SITES, DIRS, ROOT_DIR, title="latex")
         self.assertIn("<p>$$", html)
         self.assertIn("\\begin{array}{rcl}", html)
         self.assertIn("2&5&7", html)
@@ -30,7 +39,7 @@ class TestMd2Html(unittest.TestCase):
     def test_pipeline_example(self):
         path = 'Pipeline_example.md'
         md_text = open(path, encoding='utf8').read()
-        html = markdown_to_html(md_text, title='pipeline')
+        html = markdown_to_html(md_text, HOME_PAGE, SITES, DIRS, ROOT_DIR, title='pipeline')
         # basic sanity checks
         self.assertIn('<img src="../graphics/pipeline_example.png"', html)
         self.assertIn('<button class="copy"', html)


### PR DESCRIPTION
## Summary
- expand `markdown_to_html` to include home page text and lists of links
- add sample `home_page.md`
- update CLI and tests for new parameters
- document new behaviour in README

## Testing
- `pytest -q`
- `python Main.py > /tmp/main_output.html && tail -n 5 /tmp/main_output.html`


------
https://chatgpt.com/codex/tasks/task_e_6851f77345748330b15adacf33f2f2ab