### PR TITLE
Implement generation helpers and adjust markdown_to_html

### DIFF
--- a/Pipeline_example.md
+++ b/Pipeline_example.md
@@ -1,0 +1,143 @@
+---
+tags: [zsh, pipe, pipeline, linux, command_cut, command_column, command_grep, history_substitution_operator, standard_error, redirection,]
+web_code: "dir"
+---
+##### Demonstrative pipe example
+#####Demonstrative pipe example
+
+> [!CAUTION] Title
+> Contents
+> more
+
+> [!DANGER] Title
+> Contents
+> more
+
+Creating a matrix
+$$
+\begin{array}{rcl}
+	2&5&7 \\
+	2&5&7 \\
+\end{array}
+$$
+
+> [!NOTE] Title
+> Contents
+> more
+![[pipeline_example.png]]
+Above is the partial output of the command `$ ls /bin /usr/bin`. These are the binary executables in the file system.
+Say, we wanted to remove the white text. 
+`$ ls /bin /usr/bin |grep -v '/bin:$'` 
+**Aside**, `:` (colon) is a literal colon and is not a meta-character.
+The `-v` or `--invert-match` means, everything that does not match the grep string will be printed to standard out. 
+```shell
+ $ ls /bin /usr/bin |grep -v '/bin:$'
+[
+bash
+cat
+chmod
+cp
+csh
+dash
+date
+...
+test
+unlink
+wait4path
+zsh
+...
+AssetCacheLocatorUtil
+AssetCacheManagerUtil
+AssetCacheTetheratorUtil
+DeRez
+GetFileInfo
+IOAccelMemory
+IOMFB_FDR_Loader 
+IOSDebug
+ResMerger 
+...
+```
+The above snippet is partial output from the command. Notice the ellipsis. The pesky newline after the `zsh` line is apart of the real output. Lets remove that line by a new pipe and a `grep`
+`$ ls /bin /usr/bin |grep -v '/bin:$'|grep -v '^$'`
+Understanding the regex: `'^$'` 
+`^` starting at the beginning of the line then match _nothing_ til the end of the line `$`. In tandem with the `-v` option this will output all the lines that do not match a blank line.
+###### `column`_ize_ the output
+given `proglist`, a file of the all the available commands defined as...
+`$ /bin/ls /bin /usr/bin | grep -v '/bin:$' | grep -v '^$' | sort > proglist`
+`$ cat proglist`
+```
+AssetCacheLocatorUtil
+AssetCacheManagerUtil
+AssetCacheTetheratorUtil
+DeRez
+GetFileInfo
+IOAccelMemory
+IOMFB_FDR_Loader
+IOSDebug
+ResMerger
+...
+```
+The above is partial output. Notice the ellipsis.
+`$ column proglist` 
+when given with no options will pick how many columns based off the current terminal size (the width of the window). 
+`$ column -c 50 proglist` 
+the `-c` option will output columns based on the hardcoded specifications of a terminal window being 50 columns wide.
+###### `cut`ing off excess characters 
+`$ head proglist | cut -c 1-7`
+__Aside__, `head` outputs the first ten lines. Then, `cut` based off characters (`-c`). The above command outputs the first 7 characters of each line.
+**Oops** I mean to get the fist 9 characters, not 7. Perfect time for the **history substitution operator** `^n^n` 
+`$ ^7^9`
+###### Get all programs (lines) that end in 'sh'
+`$ grep 'sh$' proglist`
+```
+afhash
+bash
+chsh
+crlrefresh
+csh
+dash
+hash
+instmodsh
+ksh
+mcxrefresh
+power_report.sh
+sh
+ssh
+```
+Modify the above command so that the commands that end in '.sh' are omitted. Good use case for `egrep` that accepts extended regular expressions. `grep -E` is the same as `egrep`. 
+`$ egrep '[^.]sh$' proglist`
+###### Conditional or in egrep's regex
+`$ egrep '[^.]sh$|ch$' proglist`
+The above command shows the regex or conditional which happens to be a pipe as well! A conditional and is achieved by separating out the conditions in different passes of the `grep` command. Yes, multiple pipelines of `grep` are necessary to achieve this. 
+###### `ls` (list) the contents of each directory in the `PATH`
+Given, the below command will outputs the paths in an arguments friendly way.
+`$ echo ${PATH}|tr ':' ' '`
+**translate** the characters from standard input. Specifically, for replace every colon with a space. Then with **command substitution** we put the standard output of the command on the command line as arguments (not through pipes as standard input). **Command substitution** is done with backticks. Think of it as an in-place substitution. 
+```shell
+$ ls `echo ${PATH}|tr ':' ' '`
+```
+###### Alternative with loops
+[[Loops|See more in Loops]]
+```shell
+for dir in  `echo ${PATH}|tr ':' ' '`
+do
+	ls $dir
+done
+```
+###### Got errors?
+Redirect to the standard error to the 'waste bin' (`/dev/null`) 
+Direct the '2' stream (file descriptor) to standard error. Modify the `ls` line with the below. 
+`ls $dir 2> /dev/null`
+######  More robust script will only call `ls` on directories
+A simple check (`test`) before the call to `ls` will suffice.
+The above for loop naively calls `ls` on everything in the `PATH`. Lets make sure the for variable is a directory before calling `ls`
+```shell
+for dir in  `echo ${PATH}|tr ':' ' '`
+do
+	if [ -d $dir ]
+	then
+		ls $dir
+	fi
+done
+```
+

--- a/home_page.md
+++ b/home_page.md
@@ -1,0 +1,1 @@
+This is the *home* page.

--- a/src/GenHTML.py
+++ b/src/GenHTML.py
@@ -1,8 +1,69 @@
+from pathlib import Path
+from typing import List, Optional
 
 __all__ = ["GenHomePage", "GenSingleton"]
 
-"""
-`root_dir`/"example_output" is the root of newly created website
-"""
-def GenHomePage(root_dir, valid_dirs): pass
-def GenSingleton(root_dir, terminal_sites): pass
+"""Helpers to generate directory index pages and standalone article pages."""
+
+
+def _load_helpers():
+    """Import helper functions from x module lazily to avoid circular imports."""
+    from . import x as core
+    return core._convert_lines, core._build_links, core._embed_in_template, core.is_valid_dir
+
+
+def GenHomePage(root_dir: Path, valid_dirs: List[str], *, base_root: Optional[Path] = None) -> None:
+    """Generate HTML homepages for subdirectories containing a README."""
+    convert, build_links, embed, is_valid = _load_helpers()
+
+    root_dir = Path(root_dir)
+    base_root = root_dir if base_root is None else Path(base_root)
+    out_root = base_root / "example_output"
+
+    for name in valid_dirs:
+        subdir = root_dir / name
+        readme = subdir / "README.md"
+        if not readme.exists():
+            continue
+
+        # Discover markdown files and further subdirectories
+        terminal_sites = [p.name for p in subdir.glob("*.md") if p.name.lower() != "readme.md"]
+        sub_valid_dirs = [d.name for d in subdir.iterdir() if d.is_dir() and is_valid(d)]
+
+        # Recursively generate children first
+        if sub_valid_dirs:
+            GenHomePage(subdir, sub_valid_dirs, base_root=base_root)
+        if terminal_sites:
+            GenSingleton(subdir, terminal_sites, base_root=base_root)
+
+        # Convert README
+        lines = readme.read_text(encoding="utf8").splitlines()
+        parts = []
+        parts.extend(convert(lines))
+        parts.extend(build_links(terminal_sites, sub_valid_dirs, Path('.')))
+        html = embed("\n".join(parts), Path("src/index.html"))
+
+        out_dir = out_root / subdir.relative_to(base_root)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "index.html").write_text(html, encoding="utf8")
+
+
+def GenSingleton(root_dir: Path, terminal_sites: List[str], *, base_root: Optional[Path] = None) -> None:
+    """Generate HTML pages for individual markdown files."""
+    convert, _, embed, _ = _load_helpers()
+
+    root_dir = Path(root_dir)
+    base_root = root_dir if base_root is None else Path(base_root)
+    out_root = base_root / "example_output"
+    rel_dir = root_dir.relative_to(base_root)
+    out_dir = out_root / rel_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for md_name in terminal_sites:
+        md_path = root_dir / md_name
+        if not md_path.is_file():
+            continue
+        lines = md_path.read_text(encoding="utf8").splitlines()
+        html = embed("\n".join(convert(lines)), Path("src/index.html"))
+        out_file = out_dir / Path(md_name).with_suffix(".html")
+        out_file.write_text(html, encoding="utf8")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary
- implement `GenHomePage` and `GenSingleton` for recursive HTML output
- adjust imports so `src` works as a package
- simplify `markdown_to_html` to accept Markdown text directly
- provide example markdown files for tests
- ensure tests can import project modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532db5011483308650438eb800d0a1